### PR TITLE
Add publications and social icons (ORCID, Google Scholar) to CV

### DIFF
--- a/_includes/resume/publications.html
+++ b/_includes/resume/publications.html
@@ -20,9 +20,18 @@
           </table>
         </div>
         <div class="col-xs-10 cl-sm-10 col-md-10 mt-2 mt-md-0">
-          <h6 class="title font-weight-bold ml-1 ml-md-4"><a href="{{ content.url }}">{{content.name}}</a></h6>
+          <h6 class="title font-weight-bold ml-1 ml-md-4">
+            {% if content.url and content.url != "" %}
+              <a href="{{ content.url }}">{{content.name}}</a>
+            {% else %}
+              {{content.name}}
+            {% endif %}
+          </h6>
           <h6 class="ml-1 ml-md-4" style="font-size: 0.95rem;">{{content.publisher}}</h6>
           <h6 class="ml-1 ml-md-4" style="font-size: 0.95rem; font-style: italic;">{{content.summary}}</h6>
+          {% if content.abstract and content.abstract != "" %}
+          <p class="pub-abstract ml-1 ml-md-4">{{content.abstract}}</p>
+          {% endif %}
         </div>
       </div>
     </li>

--- a/_layouts/cv.html
+++ b/_layouts/cv.html
@@ -52,6 +52,17 @@ layout: default
     {% if page.description %}<p class="post-description">{{ page.description }}</p>{% endif %}
   </header>
 
+  <div class="cv-social">
+    <div class="cv-social-icons">
+      {% include social.html %}
+    </div>
+    {% if site.contact_note %}
+    <div class="cv-social-note">
+      {{ site.contact_note }}
+    </div>
+    {% endif %}
+  </div>
+
   <h4>Table of contents</h4>
   <ul class="timeline">
   {% for entry in site.data.resume %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -326,6 +326,54 @@ blockquote {
   }
 }
 
+// CV social icons bar
+.cv-social {
+  text-align: center;
+  margin-top: 0.5rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--global-divider-color);
+
+  .cv-social-icons {
+    font-size: 2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.5rem;
+      height: 2.5rem;
+      border-radius: 50%;
+      transition: all 0.2s ease-in-out;
+
+      i::before {
+        color: var(--global-text-color);
+        transition: all 0.2s ease-in-out;
+      }
+
+      &:hover {
+        text-decoration: none;
+        background-color: var(--global-theme-color);
+
+        i::before {
+          color: var(--global-bg-color);
+        }
+      }
+    }
+  }
+
+  .cv-social-note {
+    font-size: 0.85rem;
+    color: var(--global-text-color-light);
+    margin-top: 0.5rem;
+  }
+}
+
 
 // Footer
 footer.fixed-bottom {

--- a/_sass/_cv.scss
+++ b/_sass/_cv.scss
@@ -6,6 +6,18 @@ div.container-link-button {
   margin-right: 0.5rem;
 }
 
+p.pub-abstract {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--global-text-color-light);
+  margin-top: 0.5rem;
+  margin-bottom: 0.25rem;
+  padding: 0.6rem 0.8rem;
+  background-color: var(--global-code-bg-color);
+  border-left: 3px solid var(--global-theme-color);
+  border-radius: 0 4px 4px 0;
+}
+
 table.table-cv {
   background-color: transparent !important;
 }

--- a/assets/json/resume.json
+++ b/assets/json/resume.json
@@ -7,6 +7,28 @@
   "education": [],
   "work": [],
   "projects": [],
-  "publications": [],
+  "publications": [
+    {
+      "name": "TDiff-HSI: Tucker-guided diffusion for high-dimensional RGB-to-HSI image generation",
+      "publisher": "Journal of Computational Design and Engineering, Oxford University Press",
+      "releaseDate": "2026-02-02",
+      "url": "https://doi.org/10.1093/jcde/qwag008",
+      "summary": "Jaeik Bae, Yong-Gu Lee"
+    },
+    {
+      "name": "BISeg: Band-Interval Selection for Explainable Hyperspectral Segmentation",
+      "publisher": "CIKM 2025 Workshop on Human-Centric AI (HCAI), COEX, Seoul, Korea",
+      "releaseDate": "2025-11-14",
+      "url": "https://xai.kaist.ac.kr/static/files/2025_hcai_workshop/paper_19.pdf",
+      "summary": "Jaeik Bae, Yong-Gu Lee"
+    },
+    {
+      "name": "R2H-Diff: Spectral-wise Diffusion for Hyperspectral Image Reconstruction from RGB and Semantic Masks",
+      "publisher": "Korean Society for Military Science and Technology Annual Conference 2025",
+      "releaseDate": "2025-06-11",
+      "url": "",
+      "summary": "Jaeik Bae, Yong-Gu Lee"
+    }
+  ],
   "awards": []
 }

--- a/assets/json/resume.json
+++ b/assets/json/resume.json
@@ -4,8 +4,38 @@
     "email": "jaeikb38@gm.gist.ac.kr",
     "major": "Computer Science & Artificial Intelligence"
   },
-  "education": [],
-  "work": [],
+  "education": [
+    {
+      "institution": "Gwangju Institute of Science and Technology (GIST)",
+      "area": "AI Graduate School",
+      "studyType": "Integrated M.S./Ph.D.",
+      "startDate": "2023-09",
+      "location": "Gwangju, South Korea"
+    },
+    {
+      "institution": "Yonsei University (Wonju)",
+      "area": "Computer Engineering",
+      "studyType": "B.S.",
+      "startDate": "2018-03",
+      "endDate": "2023-09",
+      "location": "Wonju, South Korea"
+    }
+  ],
+  "work": [
+    {
+      "name": "GIST Autonomous Driving Lab",
+      "position": "Integrated M.S./Ph.D. Student",
+      "startDate": "2023-09",
+      "summary": "Research on hyperspectral image generation and autonomous driving"
+    },
+    {
+      "name": "InBic AI",
+      "position": "AI Intern",
+      "startDate": "2023-01",
+      "endDate": "2023-03",
+      "summary": "AI edge device (Jetson) environment setup and operation experiments"
+    }
+  ],
   "projects": [],
   "publications": [
     {

--- a/assets/json/resume.json
+++ b/assets/json/resume.json
@@ -43,21 +43,24 @@
       "publisher": "Journal of Computational Design and Engineering, Oxford University Press",
       "releaseDate": "2026-02-02",
       "url": "https://doi.org/10.1093/jcde/qwag008",
-      "summary": "Jaeik Bae, Yong-Gu Lee"
+      "summary": "Jaeik Bae, Yong-Gu Lee",
+      "abstract": "We introduce TDiff-HSI, a diffusion-based model that can generate hyperspectral images (HSIs) directly from RGB images and material-wise segmentation masks. HSI provides both spatial (u, v) and spectral (\u03bb) information. The accompanying dataset that we are releasing spans wavelengths in the range from 420 to 1728 nm, digitized into 512 channels. Directly handling this immense three-dimensional dataset is computationally prohibitive and often leads to numerical errors. To address this challenge, TDiff-HSI leverages Tucker decomposition to reduce dimensionality, enabling more stable and efficient processing. Moreover, spectral precision is enhanced by combining RGB channels with a material segmentation mask. To support this research, we constructed a new dataset using a hyperspectral camera. The dataset comprises 40,014 RGB-HSI pairs across 78 scenes, featuring 12 objects with diverse material properties."
     },
     {
       "name": "BISeg: Band-Interval Selection for Explainable Hyperspectral Segmentation",
       "publisher": "CIKM 2025 Workshop on Human-Centric AI (HCAI), COEX, Seoul, Korea",
       "releaseDate": "2025-11-14",
       "url": "https://xai.kaist.ac.kr/static/files/2025_hcai_workshop/paper_19.pdf",
-      "summary": "Jaeik Bae, Yong-Gu Lee"
+      "summary": "Jaeik Bae, Yong-Gu Lee",
+      "abstract": ""
     },
     {
       "name": "R2H-Diff: Spectral-wise Diffusion for Hyperspectral Image Reconstruction from RGB and Semantic Masks",
       "publisher": "Korean Society for Military Science and Technology Annual Conference 2025",
       "releaseDate": "2025-06-11",
       "url": "",
-      "summary": "Jaeik Bae, Yong-Gu Lee"
+      "summary": "Jaeik Bae, Yong-Gu Lee",
+      "abstract": ""
     }
   ],
   "awards": []

--- a/assets/json/resume.json
+++ b/assets/json/resume.json
@@ -26,7 +26,7 @@
       "name": "GIST Autonomous Driving Lab",
       "position": "Integrated M.S./Ph.D. Student",
       "startDate": "2023-09",
-      "summary": "Research on hyperspectral image generation and autonomous driving"
+      "summary": "Generative AI / Autonomous Driving Research"
     },
     {
       "name": "InBic AI",

--- a/assets/json/resume.json
+++ b/assets/json/resume.json
@@ -52,7 +52,7 @@
       "releaseDate": "2025-11-14",
       "url": "https://xai.kaist.ac.kr/static/files/2025_hcai_workshop/paper_19.pdf",
       "summary": "Jaeik Bae, Yong-Gu Lee",
-      "abstract": ""
+      "abstract": "We introduce BISeg, a novel hyperspectral image (HSI) segmentation model that achieves both accuracy and interpretability through band-interval selection. Unlike conventional approaches that rely on post-hoc band attribution, BISeg intrinsically learns to identify compact spectral windows during training. Each interval is parameterized by its center wavelength and width, with a maximum of ten intervals activated. A dedicated regularization encourages the use of fewer and narrower intervals, ensuring explanations remain concise and physically meaningful. The proposed spectral\u2013spatial backbone integrates these intervals with spatial features via cross-axis attention, and a query-based head outputs pixel-level mask. Experiments on our custom HSI dataset, covering nine material classes, demonstrate that BISeg achieves competitive segmentation accuracy while producing interpretable spectral intervals aligned with known material properties."
     },
     {
       "name": "R2H-Diff: Spectral-wise Diffusion for Hyperspectral Image Reconstruction from RGB and Semantic Masks",
@@ -60,7 +60,7 @@
       "releaseDate": "2025-06-11",
       "url": "",
       "summary": "Jaeik Bae, Yong-Gu Lee",
-      "abstract": ""
+      "abstract": "We propose R2H-Diff, a diffusion-based model that reconstructs hyperspectral images (HSIs) using RGB images and semantic masks. Instead of generating the full spectrum at once, our model sequentially restores each spectral channel for greater training stability. A single-scene experiment validates its ability to denoise and reconstruct spectral data effectively."
     }
   ],
   "awards": []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### 1. Add Publication Records
Add three publication records to `assets/json/resume.json`:

1. **TDiff-HSI: Tucker-guided diffusion for high-dimensional RGB-to-HSI image generation**
   - Journal of Computational Design and Engineering, Oxford University Press
   - Published: 2026-02-02
   - DOI: https://doi.org/10.1093/jcde/qwag008

2. **BISeg: Band-Interval Selection for Explainable Hyperspectral Segmentation**
   - CIKM 2025 Workshop on Human-Centric AI (HCAI), COEX, Seoul, Korea
   - Published: 2025-11-14
   - Paper: https://xai.kaist.ac.kr/static/files/2025_hcai_workshop/paper_19.pdf

3. **R2H-Diff: Spectral-wise Diffusion for Hyperspectral Image Reconstruction from RGB and Semantic Masks**
   - Korean Society for Military Science and Technology Annual Conference 2025
   - Published: 2025-06-11

### 2. Add Social Icons Bar to CV Page
Previously, ORCID and Google Scholar links were configured in `_config.yml` but `social.html` was never rendered on the CV page.

**Fix**: Added a social icons bar directly into the CV layout, displayed prominently between the header and table of contents.

### 3. Add Education & Work Experience
- **Education**: GIST Integrated M.S./Ph.D. (2023.09~), Yonsei Univ. B.S. (2018.03~2023.09)
- **Work**: GIST Autonomous Driving Lab (2023.09~), InBic AI Intern (2023.01~2023.03)

### 4. Add Abstracts to Publications
- Added `abstract` field to publications in resume.json
- Modified publications template to display abstracts inline with left-border accent styling
- TDiff-HSI abstract filled; BISeg and R2H-Diff abstracts to be added
- Fixed empty URL rendering (no dead links when URL is empty)

## Changes

- `assets/json/resume.json` - Added publications (3), education (2), work (2), abstracts
- `_layouts/cv.html` - Added `{% include social.html %}` section
- `_includes/resume/publications.html` - Added abstract display and smart URL handling
- `_sass/_base.scss` - Added `.cv-social` styles
- `_sass/_cv.scss` - Added `.pub-abstract` styles
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6108f8c4-e530-4b40-bdf4-307faf6a5768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6108f8c4-e530-4b40-bdf4-307faf6a5768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

