### PR TITLE
CV 인쇄 스타일 개선 + PR 미리보기 워크플로 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,13 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: "pages-${{ github.ref }}"
+  group: pages
   cancel-in-progress: true
 
 jobs:
@@ -35,7 +32,8 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Deploy
-        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: _site
+          clean-exclude: pr-preview
+          force: false

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,41 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        if: github.event.action != 'closed'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2.2"
+          bundler-cache: true
+
+      - name: Build with preview baseurl
+        if: github.event.action != 'closed'
+        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.number }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ navbar_fixed: true
 footer_fixed: false
 
 # Dimensions
-max_width: 800px
+max_width: 960px
 
 # -----------------------------------------------------------------------------
 # Open Graph & Schema.org

--- a/_layouts/cv.html
+++ b/_layouts/cv.html
@@ -60,7 +60,7 @@ layout: default
   <!-- Resume Header (print-friendly) -->
   <header class="cv-resume-header">
     <h1 class="cv-resume-name">{{ site.data.resume.basics.name }}</h1>
-    <div class="cv-resume-contact">
+    <div class="cv-resume-contact cv-resume-contact-row1">
       {% if site.data.resume.basics.major %}
       <span class="cv-resume-contact-item">
         <i class="fas fa-graduation-cap"></i> {{ site.data.resume.basics.major }}
@@ -81,6 +81,8 @@ layout: default
         <i class="fas fa-globe"></i> <a href="{{ site.data.resume.basics.url }}">{{ site.data.resume.basics.url }}</a>
       </span>
       {% endif %}
+    </div>
+    <div class="cv-resume-contact cv-resume-contact-row2">
       {% if site.github_username %}
       <span class="cv-resume-contact-item">
         <i class="fab fa-github"></i> <a href="https://github.com/{{ site.github_username }}">{{ site.github_username }}</a>
@@ -88,7 +90,7 @@ layout: default
       {% endif %}
       {% if site.scholar_userid %}
       <span class="cv-resume-contact-item">
-        <i class="ai ai-google-scholar"></i> <a href="https://scholar.google.com/citations?user={{ site.scholar_userid }}">Google Scholar</a>
+        <i class="ai ai-google-scholar"></i> <a href="https://scholar.google.com/citations?user={{ site.scholar_userid }}">scholar.google.com/citations?user={{ site.scholar_userid }}</a>
       </span>
       {% endif %}
       {% if site.orcid_id %}

--- a/_sass/_cv.scss
+++ b/_sass/_cv.scss
@@ -57,9 +57,16 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 0.5rem 1.25rem;
+  gap: 0.25rem 1.25rem;
   font-size: 0.9rem;
   color: var(--global-text-color-light);
+}
+
+.cv-resume-contact-row1 {
+  padding-bottom: 0;
+}
+
+.cv-resume-contact-row2 {
   padding-bottom: 0.5rem;
 }
 
@@ -479,12 +486,20 @@ ul.timeline li::before {
   .cv-resume-contact {
     font-size: 9pt !important;
     color: #333 !important;
-    gap: 4pt 12pt;
+    gap: 2pt 12pt;
 
     a {
       color: #333 !important;
       text-decoration: none !important;
     }
+  }
+
+  .cv-resume-contact-row1 {
+    padding-bottom: 0 !important;
+  }
+
+  .cv-resume-contact-row2 {
+    padding-bottom: 4pt !important;
   }
 
   .cv-resume-contact-item i {

--- a/_sass/_cv.scss
+++ b/_sass/_cv.scss
@@ -46,9 +46,9 @@
 }
 
 .cv-resume-name {
-  font-size: 2.2rem;
+  font-size: 2.5rem;
   font-weight: 700;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   margin-bottom: 0.5rem;
   color: var(--global-text-color);
 }
@@ -58,7 +58,7 @@
   flex-wrap: wrap;
   justify-content: center;
   gap: 0.5rem 1.25rem;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--global-text-color-light);
   padding-bottom: 0.5rem;
 }
@@ -95,11 +95,12 @@
 
 .cv-section-title {
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 1.15rem;
-  border-bottom: 1px solid var(--global-divider-color);
+  letter-spacing: 0.06em;
+  font-size: 1.25rem;
+  border-bottom: 1.5px solid var(--global-theme-color);
   padding-bottom: 0.4rem;
   margin-bottom: 0.75rem;
+  color: var(--global-theme-color);
 }
 
 .cv-inline-separator {
@@ -412,7 +413,7 @@ ul.timeline li::before {
 @media print {
   @page {
     size: A4;
-    margin: 12mm 15mm 12mm 15mm;
+    margin: 10mm 12mm 10mm 12mm;
   }
 
   * {
@@ -421,8 +422,8 @@ ul.timeline li::before {
   }
 
   html, body {
-    font-size: 10pt !important;
-    line-height: 1.35 !important;
+    font-size: 11pt !important;
+    line-height: 1.4 !important;
     color: #000 !important;
     background: #fff !important;
     margin: 0 !important;
@@ -434,7 +435,6 @@ ul.timeline li::before {
     padding-top: 0 !important;
   }
 
-  // Hide non-resume elements
   .no-print,
   nav#navbar,
   header > nav,
@@ -460,27 +460,26 @@ ul.timeline li::before {
     margin-top: 0 !important;
   }
 
-  // Resume Header for print
   .cv-resume-header {
     text-align: center;
     padding: 0 0 6pt;
-    margin-bottom: 6pt;
-    border-bottom: 2pt solid #333;
+    margin-bottom: 8pt;
+    border-bottom: 2pt solid #1a365d;
     page-break-after: avoid;
   }
 
   .cv-resume-name {
-    font-size: 20pt !important;
+    font-size: 22pt !important;
     font-weight: 700;
     color: #000 !important;
-    margin-bottom: 4pt;
-    letter-spacing: 0.08em;
+    margin-bottom: 5pt;
+    letter-spacing: 0.06em;
   }
 
   .cv-resume-contact {
-    font-size: 8.5pt !important;
+    font-size: 9pt !important;
     color: #333 !important;
-    gap: 4pt 10pt;
+    gap: 4pt 12pt;
 
     a {
       color: #333 !important;
@@ -489,34 +488,32 @@ ul.timeline li::before {
   }
 
   .cv-resume-contact-item i {
-    color: #555 !important;
-    font-size: 7.5pt !important;
+    color: #1a365d !important;
+    font-size: 8pt !important;
   }
 
-  // Section cards
   .cv .card,
   .cv .cv-section {
     border: none !important;
     box-shadow: none !important;
     background: transparent !important;
-    margin-top: 4pt !important;
+    margin-top: 6pt !important;
     padding: 2pt 0 !important;
     page-break-inside: avoid;
   }
 
   .cv-section-title,
   .cv .card-title {
-    font-size: 11pt !important;
+    font-size: 12pt !important;
     font-weight: 700 !important;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: #000 !important;
-    border-bottom: 1px solid #999 !important;
-    padding-bottom: 2pt !important;
+    letter-spacing: 0.06em;
+    color: #1a365d !important;
+    border-bottom: 1.5px solid #1a365d !important;
+    padding-bottom: 3pt !important;
     margin-bottom: 6pt !important;
   }
 
-  // List group items
   .list-group-item {
     border: none !important;
     padding: 3pt 0 !important;
@@ -524,62 +521,56 @@ ul.timeline li::before {
     page-break-inside: avoid;
   }
 
-  // Badge (date)
   .badge {
-    font-size: 7pt !important;
+    font-size: 7.5pt !important;
     font-weight: 600 !important;
     color: #fff !important;
-    background-color: #444 !important;
-    padding: 1pt 4pt !important;
+    background-color: #1a365d !important;
+    padding: 1.5pt 5pt !important;
     border-radius: 2px !important;
   }
 
-  // Title and details
   h6.title {
-    font-size: 9.5pt !important;
+    font-size: 10.5pt !important;
     font-weight: 700 !important;
     color: #000 !important;
     margin-bottom: 1pt !important;
   }
 
   h6 {
-    font-size: 9pt !important;
+    font-size: 9.5pt !important;
     color: #333 !important;
     margin-bottom: 1pt !important;
   }
 
-  // Publication abstract
   p.pub-abstract {
-    font-size: 8pt !important;
-    line-height: 1.3 !important;
-    color: #444 !important;
-    background-color: #f8f8f8 !important;
-    border-left: 2pt solid #666 !important;
-    padding: 4pt 6pt !important;
+    font-size: 8.5pt !important;
+    line-height: 1.35 !important;
+    color: #333 !important;
+    background-color: #f5f7fa !important;
+    border-left: 2pt solid #1a365d !important;
+    padding: 5pt 8pt !important;
     margin-top: 3pt !important;
     margin-bottom: 2pt !important;
     page-break-inside: avoid;
   }
 
-  // Links: show as plain text in print
   a {
     color: #000 !important;
     text-decoration: none !important;
   }
 
-  // Location text
   p.location {
-    font-size: 7pt !important;
+    font-size: 7.5pt !important;
     color: #555 !important;
   }
 
   i.iconlocation,
   i.iconinstitution,
   i.icondepartment {
-    color: #555 !important;
+    color: #1a365d !important;
   }
 
-  // Reduce spacing
   .post {
     margin: 0 !important;
     padding: 0 !important;
@@ -609,7 +600,6 @@ ul.timeline li::before {
     padding: 4pt !important;
   }
 
-  // Page break control
   .cv-section {
     page-break-inside: avoid;
   }
@@ -618,41 +608,38 @@ ul.timeline li::before {
     page-break-before: avoid;
   }
 
-  // Table fixes
   table.table-cv,
   table.table-cv-map,
   table.institution {
     background: transparent !important;
   }
 
-  // Items list
   ul.items {
     margin-top: 2pt !important;
     margin-bottom: 2pt !important;
     padding-left: 14pt !important;
 
     li {
-      font-size: 8.5pt !important;
-      line-height: 1.35 !important;
+      font-size: 9pt !important;
+      line-height: 1.4 !important;
     }
   }
 
-  // Project meta (funder, role)
   .cv-project-name-en {
-    font-size: 8pt !important;
+    font-size: 8.5pt !important;
     color: #555 !important;
     margin-bottom: 1pt !important;
   }
 
   .cv-project-meta {
-    font-size: 7.5pt !important;
+    font-size: 8pt !important;
     color: #555 !important;
-    gap: 1pt 8pt;
+    gap: 2pt 8pt;
     margin-bottom: 2pt !important;
 
     i {
-      color: #666 !important;
-      font-size: 6.5pt !important;
+      color: #1a365d !important;
+      font-size: 7pt !important;
     }
   }
 
@@ -660,9 +647,8 @@ ul.timeline li::before {
     page-break-inside: avoid;
   }
 
-  // Basics table (if still rendered somewhere)
   .table-cv-map td {
-    font-size: 9pt !important;
-    padding: 1pt 4pt !important;
+    font-size: 10pt !important;
+    padding: 2pt 4pt !important;
   }
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -17,7 +17,7 @@ $green-color-lime:    #B7D12A !default;
 $green-color-dark:    #009f06 !default;
 $green-color-light:   #ddffdd !default;
 $green-color-bright:  #11D68B !default;
-$purple-color:        #B509AC !default;
+$purple-color:        #1a365d !default;
 $light-purple-color:  lighten($purple-color, 25%);
 $pink-color:          #f92080 !default;
 $pink-color-light:    #ffdddd !default;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 변경 사항

### 1. CV 인쇄 스타일 개선

#### 테마 색상 변경
- **보라색 (`#B509AC`)** → **다크 네이비 블루 (`#1a365d`)**
- 학술/전문 이력서에 적합한 차분하고 전문적인 색상

#### 인쇄 글씨 크기 확대
| 요소 | 변경 전 | 변경 후 |
|------|---------|---------|
| 본문 기본 | 10pt | 11pt |
| 이름 | 20pt | 22pt |
| 섹션 제목 | 11pt | 12pt |
| 항목 제목 (h6.title) | 9.5pt | 10.5pt |
| 세부사항 (h6) | 9pt | 9.5pt |
| 초록 (abstract) | 8pt | 8.5pt |
| 항목 목록 (li) | 8.5pt | 9pt |
| 연락처 | 8.5pt | 9pt |

#### 너비 조정
- 화면 최대 너비: 800px → 960px
- 인쇄 여백: 15mm → 12mm (좌우)
- 줄간격: 1.35 → 1.4

---

### 2. 헤더 연락처 두 줄로 분리

기존에 한 줄로 길게 이어지던 연락처 정보를 두 줄로 나눔:
- **1줄:** 전공, 이메일, 전화, 웹사이트
- **2줄:** GitHub, Google Scholar, ORCID

Google Scholar 링크: "Google Scholar" 텍스트 → 전체 URL 표시로 변경하여 인쇄물에서도 직접 접근 가능

---

### 3. PR 미리보기 워크플로 추가

PR이 올라오면 자동으로 GitHub Pages 미리보기가 생성됩니다.

**동작 방식:**
- PR `opened`/`reopened`/`synchronize` → Jekyll 빌드 후 `gh-pages` 브랜치의 `pr-preview/pr-N/` 경로에 배포
- PR `closed` → 미리보기 자동 정리
- PR에 미리보기 URL 코멘트 자동 게시

**기술 세부사항:**
- `rossjrw/pr-preview-action@v1` 사용
- Jekyll 빌드 시 `--baseurl "/pr-preview/pr-N"`으로 에셋 경로 보정
- 기존 `deploy.yml`에 `clean-exclude: pr-preview` + `force: false` 추가하여 메인 배포가 미리보기를 삭제하지 않도록 보호

**미리보기 URL 형식:** `https://jaeikbae.github.io/pr-preview/pr-9/`

### 수정 파일
- `_sass/_variables.scss` — 테마 색상 변경
- `_sass/_cv.scss` — 인쇄/화면 스타일 조정, 헤더 두 줄 레이아웃
- `_config.yml` — 최대 너비 변경
- `_layouts/cv.html` — 헤더 연락처 두 줄 분리, Google Scholar URL 표시
- `.github/workflows/pr-preview.yml` — **신규** PR 미리보기 워크플로
- `.github/workflows/deploy.yml` — PR 트리거 제거, 미리보기 보호 설정 추가
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-756b121c-c25b-458d-b9d0-290166ecaf1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-756b121c-c25b-458d-b9d0-290166ecaf1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

